### PR TITLE
wire up payments - outlays NOT updated

### DIFF
--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -29,7 +29,7 @@ def createprism(plugin, members, prism_id=""):
     prism_json = prism.to_json()
 
     # return the prism json
-    return prism.to_json()
+    return prism.to_dict()
 
 
 @plugin.method("prism-show")

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -353,8 +353,9 @@ def on_payment(plugin, invoice_payment, **kwargs):
         except Exception as e:
             plugin.log(f"ERROR: there was a problem paying prism {binding.get('prism-id')}. Outlays may not have been updated properly. throwing...{e}")
 
-#         # for prism_id in binding.prism_ids:
-#         #     prism_execute(prism_id, int(amount_msat), payment_label)
+        # invoices can only be paid once, so we delete the bolt11 binding
+        if bind_type is "bolt11":
+            PrismBinding.delete(plugin, bind_to, bolt_version=bind_type)
 
     except Exception as e:
         raise Exception("Payment error: {}".format(e))

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -26,8 +26,6 @@ def createprism(plugin, members, prism_id=""):
     # save all the record to the database
     prism.save(plugin)
 
-    prism_json = prism.to_json()
-
     # return the prism json
     return prism.to_dict()
 
@@ -216,7 +214,8 @@ def bindprism(plugin: Plugin, prism_id, bind_to, bolt_version="bolt12"):
 def prism_execute(plugin, prism_id, amount_msat=0, label=""):
     '''Executes (pays-out) a prism.'''
 
-    plugin.log(f"In prism_execute with prism_ID {prism_id} and amount = {amount_msat}")
+    plugin.log(
+        f"In prism_execute with prism_ID {prism_id} and amount = {amount_msat}")
 
     if not isinstance(amount_msat, int):
         raise Exception("ERROR: amount_msat is the incorrect type.")
@@ -228,7 +227,8 @@ def prism_execute(plugin, prism_id, amount_msat=0, label=""):
     # # TODO; first thing we should do here probably is update the Prism with new outlay values.
     # # that way we can immediately record/persist
     plugin.log(f"{amount_msat}")
-    plugin.log(f"Starting prism_execute for prism_id: {prism_id} for {amount_msat}msats.")
+    plugin.log(
+        f"Starting prism_execute for prism_id: {prism_id} for {amount_msat}msats.")
 
     prism = Prism.get(plugin, prism_id)
 
@@ -241,8 +241,8 @@ def prism_execute(plugin, prism_id, amount_msat=0, label=""):
     pay_results = prism.pay(plugin, amount_msat=amount_msat)
 
     return pay_results
-    # # sum all the member split variables.
-    # sum_of_member_splits = sum(map(lambda member: member.split, prism.members))
+
+    # TODO: move the below code into prism.pay
 
     # # this for loop basically updates all the prism member outlay database records...
     # # we don't execute payments in this loop.
@@ -305,15 +305,10 @@ def prism_execute(plugin, prism_id, amount_msat=0, label=""):
     #         else:
     #             raise Exception("ERROR: something went wrong. The payment type was not correct.")
 
-# # Function to find the binding with the specified offer_id
-# def find_binding_by_offer_id(bindings, offer_id, bolt_version="bolt12"):
-#     for binding in bindings:
-#         if binding.get("offer_id") == offer_id:
-#             return binding
-#     return None
-
 # # ABOUT: First, we check the db to see if there are any bindings associated with
 # # the invoice payment.
+
+
 @plugin.subscribe("invoice_payment")
 def on_payment(plugin, invoice_payment, **kwargs):
 
@@ -336,12 +331,12 @@ def on_payment(plugin, invoice_payment, **kwargs):
             bind_to = payment_label
             bind_type = "bolt11"
 
-
         plugin.log(f"BIND_TYPE: {bind_type}")
 
         amount_msat = invoice_payment['msat'][:-4]
 
-        plugin.log(f"payment_label:  {payment_label}; amount_msat:  {amount_msat}")
+        plugin.log(
+            f"payment_label:  {payment_label}; amount_msat:  {amount_msat}")
 
         # TODO: return PrismBinding.get as class member rather than json
         binding = PrismBinding.get(plugin, bind_to, bind_type)
@@ -351,7 +346,8 @@ def on_payment(plugin, invoice_payment, **kwargs):
         try:
             prism.pay(plugin=plugin, amount_msat=int(amount_msat))
         except Exception as e:
-            plugin.log(f"ERROR: there was a problem paying prism {binding.get('prism-id')}. Outlays may not have been updated properly. throwing...{e}")
+            plugin.log(
+                f"ERROR: there was a problem paying prism {binding.get('prism-id')}. Outlays may not have been updated properly. throwing...{e}")
 
         # invoices can only be paid once, so we delete the bolt11 binding
         if bind_type is "bolt11":

--- a/lib.py
+++ b/lib.py
@@ -194,12 +194,14 @@ class Prism:
 
         for m in self.members:
             # total_msat * (member_split / total_split)
-            member_msat = math.floor(amount_msat * (m.split / self.total_splits))
+            member_msat = math.floor(
+                amount_msat * (m.split / self.total_splits))
 
             member_offer = m.destination
             # fetch invoice from memeber's BOLT 12
             try:
-                invoice = plugin.rpc.fetchinvoice(offer=member_offer, amount_msat=member_msat)
+                invoice = plugin.rpc.fetchinvoice(
+                    offer=member_offer, amount_msat=member_msat)
             except RpcError as e:
                 # TODO: add as error to results
                 plugin.log(f"error fetching invoice {e}", 'error')
@@ -214,13 +216,13 @@ class Prism:
             except RpcError as e:
                 # TODO: add as error to results
                 plugin.log(f"error paying prism member: {e}", 'error')
-            
+
             # map payment results to member ID for succuess/fail handling
             results[member_id] = payment
 
-        plugin.log(f"PRISM-PAY - ID={self.id}; BOLT=12: {len(self.members)} members; {amount_msat} msat total", 'info')
+        plugin.log(
+            f"PRISM-PAY - ID={self.id}; BOLT=12: {len(self.members)} members; {amount_msat} msat total", 'info')
         return results
-
 
     @staticmethod
     def from_db_string(plugin: Plugin, prism_string: str):
@@ -352,14 +354,13 @@ class PrismBinding:
 
         try:
             binding_records = plugin.rpc.deldatastore(
-            key=bindings_key)
+                key=bindings_key)
         except RpcError as e:
             plugin.log(f"ERROR DELETING: {e}", 'error')
-        
+
         if not binding_records:
             raise Exception(
                 f"Could not find a prism binding for offer {bind_to}")
-
 
     @staticmethod
     def get(plugin: Plugin, bind_to: str, bolt_version="bolt12"):

--- a/lib.py
+++ b/lib.py
@@ -340,6 +340,28 @@ class PrismBinding:
     # bindings are
 
     @staticmethod
+    def delete(plugin: Plugin, bind_to: str, bolt_version="bolt12"):
+        # TODO: below code is repeated from PrismBinding.get()
+        types = ["bolt11", "bolt12"]
+        if bolt_version not in types:
+            raise Exception(
+                "ERROR: 'type' MUST be either 'bolt12' or 'bolt11'.")
+
+        bindings_key = ["prism", prism_db_version,
+                        "bind", bolt_version, bind_to]
+
+        try:
+            binding_records = plugin.rpc.deldatastore(
+            key=bindings_key)
+        except RpcError as e:
+            plugin.log(f"ERROR DELETING: {e}", 'error')
+        
+        if not binding_records:
+            raise Exception(
+                f"Could not find a prism binding for offer {bind_to}")
+
+
+    @staticmethod
     def get(plugin: Plugin, bind_to: str, bolt_version="bolt12"):
 
         plugin.log(f"got into get_binding_state.")


### PR DESCRIPTION
This enables prisms to be payed out, but only when nothing goes wrong. There is still plenty of error handling and refactoring to be done!

### Notable changes:

-  I moved all functionality of _paying_ a prism to the `Prism.pay()` class method
      -  This means that both the payment triggers (`invoice_payment` and `executepayout`) use `.pay()` 

- Prism payouts get triggered by payment of an invoice (bolt11 or bolt12 generated)

- made sure to delete BOLT11 bindings when the payment completes

- `prism-create` now returns as a dict, not json. This makes it easier to parse the response.