### PR TITLE
Pay outlays

### DIFF
--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -14,7 +14,7 @@ def init(options, configuration, plugin, **kwargs):
     numbers = re.findall(r'v(\d+)\.', clnVersion)
     major_cln_version = int(numbers[0]) if numbers else None
     #plugin.log(f"major_cln_version: {major_cln_version}")
-    if major_cln_version is not None:
+    if major_cln_version != None:
         if major_cln_version < 24:
             raise Exception("The BOLT12 Prism plugin is only compatible with CLN v24 and above.")
 
@@ -175,7 +175,7 @@ def delete_prism(plugin, prism_id):
         raise Exception(f"Prism with ID {prism_id} does not exist.")
 
     # prism should not have bindings
-    if len(prism_to_delete.bindings) is not 0:
+    if len(prism_to_delete.bindings) != 0:
         raise Exception(
             f"This prism has existing bindings! Use prism-bindingremove [offer_id=] before attempting to delete prism '{prism_id}'.")
     

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -252,21 +252,16 @@ def on_payment(plugin, invoice_payment, **kwargs):
     binding = None
     binding = PrismBinding.get(plugin, bind_to, bind_type)
 
-    plugin.log(f"test1")
-
     #plugin.log(f"binding: {binding.id}")
 
     if not binding:
         plugin.log("Incoming payment not associated with prism binding. Nothing to do.", "info")
         return
 
-    plugin.log(f"test2")
-
     # try:
     amount_msat = invoice_payment['msat']
     plugin.log(f"amount_msat: {amount_msat}")
     binding.pay(amount_msat=int(amount_msat))
-    plugin.log(f"test3")
     # except Exception as e:
     #     plugin.log(
     #         f"ERROR: something went wrong with binding payout {binding.prism.id}. {e}")

--- a/lib.py
+++ b/lib.py
@@ -254,7 +254,7 @@ class Prism:
 
         return rtnVal
 
-    def pay(self, amount_msat: int, binding: None):
+    def pay(self, amount_msat: int, binding = None):
         """
         Pay each member in the prism their respective share of `amount_msat`
         """

--- a/lib.py
+++ b/lib.py
@@ -254,26 +254,34 @@ class Prism:
 
         return rtnVal
 
-    def pay(self, amount_msat: int):
+    def pay(self, amount_msat: int, binding: None):
         """
         Pay each member in the prism their respective share of `amount_msat`
         """
 
-        pay_queue = {}
         results = {}
 
         for m in self.members:
-            
-            # this member_msat SHOULD BE the member outlay.
-            member_msat = math.floor(amount_msat * (m.split / self.total_splits))
-            #self._plugin.log(f"member_msat {member_msat} ")
+            member_msat = 0
+
+            if binding is None:
+                # when a binding is not provided (when we're using prism.pay, for example)
+                # the member_msat is set to the proportional share of defined in the split defintion
+                member_msat = math.floor(amount_msat * (m.split / self.total_splits))
+                self._plugin.log(f"In Prism.pay, but no binding was provided. Setting member_msat to {member_msat}")
+                #self._plugin.log(f"member_msat {member_msat} ")
+            else:
+                # but if the user provids a binding object, then we set the member_msat to the
+                # outlay for the respective prism member.
+                member_msat = binding.outlays[m.id]
+                self._plugin.log(f"In Prism.pay, and a binding was provided. Setting member_msat to the member's outlay: {member_msat}")
 
             payment = None
             if bolt12Regex.match(m.destination):
                 try:
                     self._plugin.log(f"in prism.pay_bolt12regex", 'debug')
                     bolt12_invoice = self._plugin.rpc.fetchinvoice(offer=m.destination, amount_msat=member_msat)
-                    self._plugin.log(f"after fetchinvoice")
+
                     invoice = bolt12_invoice.get("invoice")
 
                     if invoice is not None:
@@ -506,7 +514,6 @@ class PrismBinding:
         self.save()
 
     def update_outlays(self, payment_results):
-        self._plugin.log(f"Decrementing outlays.")
         new_outlays = {}
         for member_id, outlay in self.outlays.items():
             payment_amount = 0
@@ -527,7 +534,7 @@ class PrismBinding:
 
             new_outlays[member_id] = new_outlay
 
-        self._plugin.log(f"NEW OUTLAYS: {new_outlays}")
+        self._plugin.log(f"New outlay values after decrementing: {new_outlays}")
         self.outlays = new_outlays
 
         self.save()
@@ -541,7 +548,7 @@ class PrismBinding:
         self.increment_outlays(amount_msat=amount_msat)
 
         # TODO we need to narrow the gap between these two functions.
-        payment_results = self.prism.pay(amount_msat)
+        payment_results = self.prism.pay(amount_msat, binding=self)
         self.update_outlays(payment_results)
         # ################3
 


### PR DESCRIPTION
This pull request fixes an issue where outlays were not used when setting the payment amount. This is fine for something like prism.pay, but for bindings, outlay values should be used for the payout amount.