### PR TITLE
bind to id of prism object, not `prism_id` param passed to `prism-cre…

### DIFF
--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -50,7 +50,7 @@ def createprism(plugin, members, prism_id="", outlay_factor: float = 1.0, pay_to
         create_offer_response = plugin.rpc.offer(amount="any", description=prism_id, label="internal:prism")
         ptsd_offer_id = create_offer_response["offer_id"]
         plugin.log(f"In prism-create. Trying to create a PTSD offer binding. here's the ptsd_offer_bolt12 {ptsd_offer_id}")
-        bind_prism_response = bindprism(plugin=plugin, prism_id=prism_id, offer_id=ptsd_offer_id)
+        bind_prism_response = bindprism(plugin=plugin, prism_id=prism.id, offer_id=ptsd_offer_id)
 
     # return the prism json
     return prism.to_dict()


### PR DESCRIPTION
bind to id of prism object, not `prism_id` param passed to `prism-create`

When you try to create a prism and do not specify a `prism_id`, then a `None` value was getting passed to `bindprism` causing it to error. I just changed to to bind to `prism.id` instead of `prism_id`