### PR TITLE
Fix Binding Outlay Tracking, update API as a result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM lnplay/cln:v24.05
-
-RUN apt update
-
 RUN apt-get update && apt-get install -y \
     python3.10 \
     python3-pip \
@@ -12,6 +9,5 @@ RUN pip install pytest pyln-testing==24.2.1
 RUN mkdir /cln-plugins
 ADD *.py /cln-plugins
 WORKDIR /cln-plugins
-ADD docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+
+ENTRYPOINT [ "python3", "-m", "pytest", "." ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tuq5hg6cxpz7e/cln:v24.02.2
+FROM lnplay/cln:v24.05
 
 RUN apt update
 

--- a/README.md
+++ b/README.md
@@ -47,43 +47,43 @@ Find your c-lightning config file and add
 
 MEMBERS_JSON=
 ```json
-[{"description" : "Guitarist", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy", "split": 0.333333, "payout_threshold_msat": "5000000", "fees_incurred_by": "local"},{"description" : "Drums", "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c", "split": 0.333333, "payout_threshold_msat": "10000000", "fees_incurred_by": "remote"},{"description" : "Tuba", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6", "split": 0.333333, "payout_threshold_msat": "5000000", "fees_incurred_by": "local"}]
+[{"description" : "Drummer", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwtzkujnk4t5hteur6cn8aqyt3v38u300ldryz6z2fw7zwr4gjxcq", "split": 1.0, "payout_threshold_msat": "0", "fees_incurred_by": "local"},{"description" : "Guitarist", "destination": "02dbfb1d0a6fbc717ae3f28e4dc185d812e399ee33055587eeb06469c94e4326e5", "split": 1.0, "payout_threshold_msat": "0", "fees_incurred_by": "remote"},{"description" : "Tuba", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqvzk2archeau0slmv7dlsvwlrcra6pxml6mdwxetsml0hhcp9w4cu", "split": 1.0, "payout_threshold_msat": "0", "fees_incurred_by": "local"}]'
 ```
 
 ```bash
-lightning-cli prism-create -k description="Band Prism" members="$MEMBERS_JSON" outlay_factor="0.8"
+lightning-cli prism-create -k description="Band Prism" members="$MEMBERS_JSON" outlay_factor="0.75"
 ```
 
 ```json
 {
-   "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+   "prism_id": "a59afe3927e6cdce218fb82415574204df4f762bb9c2c535a420488b3fa5fbf5",
    "description": "Band Prism",
-   "timestamp": 1718764199,
-   "outlay_factor": 0.8,
+   "timestamp": 1720044718,
+   "outlay_factor": 0.75,
    "prism_members": [
       {
-         "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+         "member_id": "95256245897c5423f9c319afbcd224dba9902cb829991a2435e2902631810389",
+         "description": "Drummer",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwtzkujnk4t5hteur6cn8aqyt3v38u300ldryz6z2fw7zwr4gjxcq",
+         "split": 1.0,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 0
+      },
+      {
+         "member_id": "412c79d6feafdf907a348ddb15627ba057d2c3ac3615f8f41680acd176d8bc2d",
          "description": "Guitarist",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy",
-         "split": 0.333333,
-         "fees_incurred_by": "local",
-         "payout_threshold_msat": 5000000
-      },
-      {
-         "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
-         "description": "Drums",
-         "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c",
-         "split": 0.333333,
+         "destination": "02dbfb1d0a6fbc717ae3f28e4dc185d812e399ee33055587eeb06469c94e4326e5",
+         "split": 1.0,
          "fees_incurred_by": "remote",
-         "payout_threshold_msat": 10000000
+         "payout_threshold_msat": 0
       },
       {
-         "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+         "member_id": "ebc13b1be16346e8e08571cbde85f5eb604cd76233181b5edbd559e3f35858ab",
          "description": "Tuba",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6",
-         "split": 0.333333,
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqvzk2archeau0slmv7dlsvwlrcra6pxml6mdwxetsml0hhcp9w4cu",
+         "split": 1.0,
          "fees_incurred_by": "local",
-         "payout_threshold_msat": 5000000
+         "payout_threshold_msat": 0
       }
    ]
 }
@@ -105,34 +105,34 @@ Run the following command to view a prism policy. (Note that you can add a `pris
 {
    "prisms": [
       {
-         "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
-         "description": "prism1",
-         "timestamp": 1718722200,
-         "outlay_factor": 0.8,
+         "prism_id": "4cf1e1b3e7bea1d0b8f9612ed138f164a03abe4541b1e82c8cde16af050b4f53",
+         "description": "Band Prism",
+         "timestamp": 1720042032,
+         "outlay_factor": 0.75,
          "prism_members": [
             {
-               "member_id": "b2dd7d8a70567a0e23308a6a77b38d603eaf2baca5da320082184a9951063a95",
-               "description": "Carol",
-               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0d9gxlr2q2c9rp0lkqjyztvwcl8g7gzjgu2trnwll8lraquy35vq",
+               "member_id": "547d51d513aec15dc2229047d6d912b63d39416e3682b6dee4d6ae686f88b9b4",
+               "description": "Drummer",
+               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwt5tgjxynmyjjx0zjcssjx9z5h377kewwa4k2zqtu0k8k47sscvv",
                "split": 1.0,
                "fees_incurred_by": "local",
-               "payout_threshold_msat": 5000000
+               "payout_threshold_msat": 0
             },
             {
-               "member_id": "809a721743350c0c49a7b444ad3aeaf1341fdd48d1bf510e08b008edab72dc70",
-               "description": "Dave",
-               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwv5lnjcufs7jmsh2r7wmj45mp35z822tz69n2j07gy64qn475j2c",
+               "member_id": "1fdda73dbdd4d3dda4057cf302ec10dedfc55466163133fd236e313a60a52204",
+               "description": "Guitarist",
+               "destination": "030e7553729959098adc3b63df389be92fbe0ca756a5469ba71364fc44c1338ac7",
                "split": 1.0,
                "fees_incurred_by": "remote",
-               "payout_threshold_msat": 10000000
+               "payout_threshold_msat": 0
             },
             {
-               "member_id": "849dc45741d52a071b0ed4ca14b7a182e82fcad6a60cf9b0025c903411263085",
-               "description": "Erin",
-               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwfg6tm3xapdfr0q0lqr3q5sujzznv3f9ff6wfvhl36m6scf3wzpy",
+               "member_id": "22dad0bd9cfcf4adfa367d2627e80a7a92e531b60a3d7c006495258c57b9db5e",
+               "description": "Tuba",
+               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq2zlvjv9s9she2fpj0msp6jz0sgrl7wgm425fc6rhdkhcqtqlggks",
                "split": 1.0,
                "fees_incurred_by": "local",
-               "payout_threshold_msat": 5000000
+               "payout_threshold_msat": 0
             }
          ]
       }
@@ -142,7 +142,7 @@ Run the following command to view a prism policy. (Note that you can add a `pris
 
 ## Prism-Pay - Executes a Payout
 
-`lightning-cli prism-pay -k prism_id=f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d amount_msat=10000000`
+`lightning-cli prism-pay -k prism_id=a59afe3927e6cdce218fb82415574204df4f762bb9c2c535a420488b3fa5fbf5 amount_msat=10000000`
 
 When run, this RPC command will execute (i.e., pay-out) a prism. 
 
@@ -167,18 +167,36 @@ When run, this RPC command will execute (i.e., pay-out) a prism.
          "created_at": 1718764200.7018805,
          "parts": 1,
          "amount_msat": 2666666,
-         "amount_sent_msat": 2666666,
-         "payment_preimage": "3ac15217d8f62c4c5d301b0f3a22794f9bfcaad496a20488fbc64318da893091",
+     {
+   "prism_member_payouts": {
+      "95256245897c5423f9c319afbcd224dba9902cb829991a2435e2902631810389": {
+         "destination": "03962b7253b5574baf3c1eb133f4045c5913f22f7fda320b42525de13875448d80",
+         "payment_hash": "e6dd62613b51366ce39ad9ee588e1e76a82cdd887634ffeb32f84ca9d4ead3fc",
+         "created_at": 1720044718.095364,
+         "parts": 1,
+         "amount_msat": 2500000,
+         "amount_sent_msat": 2500000,
+         "payment_preimage": "c7f0222fe6bc3df4ed14146aca88cbd79360662683d1edb71a824338add87be2",
          "status": "complete"
       },
-      "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b": {
-         "destination": "03e0a35646d33d25b85ca89314c6705be228bb137365dd8fdbfd8fd32fcfbb2cdd",
-         "payment_hash": "97f31109bc0fcb07491a4b73b6d63d0a5d8ccdc3234123d70dd2cfd651825168",
-         "created_at": 1718764201.6202407,
+      "412c79d6feafdf907a348ddb15627ba057d2c3ac3615f8f41680acd176d8bc2d": {
+         "destination": "02dbfb1d0a6fbc717ae3f28e4dc185d812e399ee33055587eeb06469c94e4326e5",
+         "payment_hash": "2a121e2ca5c6a37fe51521c8f27c30284d6469d664b9527df88ebddb29818e39",
+         "created_at": 1720044719.0942972,
          "parts": 1,
-         "amount_msat": 2666666,
-         "amount_sent_msat": 2666666,
-         "payment_preimage": "11ccae76acd177b40ebc324de0a1fb29c79b97e0d6ad3adc61883d8a4c6ee5bb",
+         "amount_msat": 2500000,
+         "amount_sent_msat": 2500000,
+         "payment_preimage": "23f75fbeb05d9a7940cb16cbf1844bb1d03046d094da131847cf9742b64a7a3d",
+         "status": "complete"
+      },
+      "ebc13b1be16346e8e08571cbde85f5eb604cd76233181b5edbd559e3f35858ab": {
+         "destination": "0305657478be7bc7c3fb679bf831df1e07dd04dbfeb6d71b2b86fefbdf012bab8e",
+         "payment_hash": "c8ad412c5f71547d0d9f62a4693c3e1a2889093e2bac06f1db696409d4122fb4",
+         "created_at": 1720044720.0844057,
+         "parts": 1,
+         "amount_msat": 2500000,
+         "amount_sent_msat": 2500000,
+         "payment_preimage": "a404ece612b6dd056f337ee8e30999044652e5a676aca5f31e5c1a00e470d9c3",
          "status": "complete"
       }
    }
@@ -193,47 +211,47 @@ Often you will want your prisms to be paid out whenever you have an incoming pay
 
 ### Create a binding
 
-`lightning-cli prism-bindingadd -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d prism_id=f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d`
+`lightning-cli prism-bindingadd -k offer_id=70761889e73c049ce243b3ac73e06533830e4cdf8dbc3a5717b05bab93c7af64 prism_id=a59afe3927e6cdce218fb82415574204df4f762bb9c2c535a420488b3fa5fbf5`
 
 The above command binds a prism (`prism_id`) to a bolt12 offer with the specified `offer_id`.
 
 ```json
 {
    "status": "must-create",
-   "timestamp": 1718764200,
-   "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
-   "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+   "timestamp": 1720044718,
+   "offer_id": "70761889e73c049ce243b3ac73e06533830e4cdf8dbc3a5717b05bab93c7af64",
+   "prism_id": "a59afe3927e6cdce218fb82415574204df4f762bb9c2c535a420488b3fa5fbf5",
    "prism_binding_key": [
       "prism",
-      "v2",
+      "v2.1",
       "bind",
       "bolt12",
-      "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d"
+      "70761889e73c049ce243b3ac73e06533830e4cdf8dbc3a5717b05bab93c7af64"
    ],
    "prism_members": [
       {
-         "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+         "member_id": "95256245897c5423f9c319afbcd224dba9902cb829991a2435e2902631810389",
+         "description": "Drummer",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwtzkujnk4t5hteur6cn8aqyt3v38u300ldryz6z2fw7zwr4gjxcq",
+         "split": 1.0,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 0
+      },
+      {
+         "member_id": "412c79d6feafdf907a348ddb15627ba057d2c3ac3615f8f41680acd176d8bc2d",
          "description": "Guitarist",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy",
-         "split": 0.333333,
-         "fees_incurred_by": "local",
-         "payout_threshold_msat": 5000000
-      },
-      {
-         "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
-         "description": "Drums",
-         "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c",
-         "split": 0.333333,
+         "destination": "02dbfb1d0a6fbc717ae3f28e4dc185d812e399ee33055587eeb06469c94e4326e5",
+         "split": 1.0,
          "fees_incurred_by": "remote",
-         "payout_threshold_msat": 10000000
+         "payout_threshold_msat": 0
       },
       {
-         "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+         "member_id": "ebc13b1be16346e8e08571cbde85f5eb604cd76233181b5edbd559e3f35858ab",
          "description": "Tuba",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6",
-         "split": 0.333333,
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqvzk2archeau0slmv7dlsvwlrcra6pxml6mdwxetsml0hhcp9w4cu",
+         "split": 1.0,
          "fees_incurred_by": "local",
-         "payout_threshold_msat": 5000000
+         "payout_threshold_msat": 0
       }
    ]
 }
@@ -243,27 +261,27 @@ The above command binds a prism (`prism_id`) to a bolt12 offer with the specifie
 
 Want to see your bindings? Run `prism-bindinglist`. Add an `offer_id` to view a specific binding.
 
-`lightning-cli -k prism-bindinglist -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d`
+`lightning-cli -k prism-bindinglist -k offer_id=dfa361b51238e8ffc4c5db74105d618090e1c7fd48442d3e735dcaaf35347b6f`
 
 ```json
 {
    "bolt12_prism_bindings": [
       {
-         "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
-         "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
-         "timestamp": 1718764200,
+         "offer_id": "dfa361b51238e8ffc4c5db74105d618090e1c7fd48442d3e735dcaaf35347b6f",
+         "prism_id": "4cf1e1b3e7bea1d0b8f9612ed138f164a03abe4541b1e82c8cde16af050b4f53",
+         "timestamp": 1720042032,
          "member_outlays": [
             {
-               "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+               "member_id": "547d51d513aec15dc2229047d6d912b63d39416e3682b6dee4d6ae686f88b9b4",
+               "outlay_msat": 50000000
+            },
+            {
+               "member_id": "1fdda73dbdd4d3dda4057cf302ec10dedfc55466163133fd236e313a60a52204",
                "outlay_msat": 0
             },
             {
-               "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
-               "outlay_msat": 5333330
-            },
-            {
-               "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
-               "outlay_msat": -1866669
+               "member_id": "22dad0bd9cfcf4adfa367d2627e80a7a92e531b60a3d7c006495258c57b9db5e",
+               "outlay_msat": 0
             }
          ]
       }
@@ -273,34 +291,32 @@ Want to see your bindings? Run `prism-bindinglist`. Add an `offer_id` to view a 
 
 The `outlay_msat` property is how the prism plugin deals with failed payments and to account for payout fees. When a prism binding has an incoming payment, prism member outlays in the binding are increased according the prism policy and incoming amount. When `fees_incurred_by=remote` and a payment to a prism member succeeds, the outlay is decremented by the total amount of the payment including fees paid. When `fees_incurred_by=local`, fees are paid by the node operator hosting the prism.
 
-Prism member payouts occur when outlays exceed the `payout_threshold_msat` in the respective prism policy. Until then, outlays accumulate and eventually get paid-out.
-
-If a payment to a prism member fails for whatever reason, the outlay remains unchanged and payout is deferred.
+Prism member payouts occur when outlays exceed the `payout_threshold_msat` in the respective prism policy. Until then, outlays accumulate. Similarly, if a payout to a prism member fails for whatever reason, the outlay remains unchanged and payout is deferred.
 
 ### Set a Binding Member Outlay
 
-Say you have outstanding outlays that aren't clearing for whatever reason (e.g., unreachable node in offer). If you know the individual, you can always remit the sats with another wallet. In those cases, you will want to first zeroize the outlays for that member in the binding:
+Say you have outstanding outlays that aren't clearing for whatever reason (e.g., unreachable node in offer). If you know the individual, you can always remit the sats with another wallet. In those cases, you will want to first zeroize the outlays for that member in the binding using the `prism-setoutlay` method.
 
-`lightning-cli prism-bindingmemberoutlayreset -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d member_id=3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b new_outlay_msat="-2500000"`
+`lightning-cli prism-setoutlay -k offer_id=dfa361b51238e8ffc4c5db74105d618090e1c7fd48442d3e735dcaaf35347b6f member_id=547d51d513aec15dc2229047d6d912b63d39416e3682b6dee4d6ae686f88b9b4 new_outlay_msat=0`
 
 ```json
 {
    "bolt12_prism_bindings": {
-      "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
-      "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
-      "timestamp": 1718764200,
+      "offer_id": "dfa361b51238e8ffc4c5db74105d618090e1c7fd48442d3e735dcaaf35347b6f",
+      "prism_id": "4cf1e1b3e7bea1d0b8f9612ed138f164a03abe4541b1e82c8cde16af050b4f53",
+      "timestamp": 1720042032,
       "member_outlays": [
          {
-            "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
-            "outlay_msat": 1066666
+            "member_id": "547d51d513aec15dc2229047d6d912b63d39416e3682b6dee4d6ae686f88b9b4",
+            "outlay_msat": 0
          },
          {
-            "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
-            "outlay_msat": 6399996
+            "member_id": "1fdda73dbdd4d3dda4057cf302ec10dedfc55466163133fd236e313a60a52204",
+            "outlay_msat": 0
          },
          {
-            "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
-            "outlay_msat": -2500000
+            "member_id": "22dad0bd9cfcf4adfa367d2627e80a7a92e531b60a3d7c006495258c57b9db5e",
+            "outlay_msat": 0
          }
       ]
    }
@@ -315,4 +331,4 @@ You can remove a binding by running `prism-bindingremove offer_id`.
 
 ## How to contribute
 
-There is a copy of the [startup_regtest](https://github.com/ElementsProject/lightning/blob/master/contrib/startup_regtest.sh) script from the c-lightning repo [contrib dir](./contrib/) for local development. Consider joining our Telegram group at [roygbiv.guide/contact](https://www.roygbiv.guide/contact).
+There is a copy of the [startup_regtest](https://github.com/ElementsProject/lightning/blob/master/contrib/startup_regtest.sh) script from the c-lightning repo [contrib dir](./contrib/) for local development. Consider joining our Telegram group at [roygbiv.guide/contribute](https://www.roygbiv.guide/contribute).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Other projects that compliment this one include:
 
 - [roygbiv.guide](https://roygbiv.guide) to learn more about prisms.
 - [lnplay](https://github.com/farscapian/lnplay) which integrates the prism plugin
-- [roygbiv-frontend](https://github.com/johngribbin/ROYGBIV-frontend) helps you manage BOLT12 prisms. TODO hackathon idea: needs UI update to v2 Prisms.
 
 ## Getting Started
 
@@ -46,54 +45,51 @@ Find your c-lightning config file and add
 
 ### Create a prism
 
-`prism-create -k members=members_json prism_id=prism1`
-
-The `prism_id` is optional. If left unspecified, a unique prism id will be assigned.
-
 MEMBERS_JSON=
 ```json
-[{"label" : "Carol", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtrvcsycd8dqycyzsqp3nf8kjtjw448ad2sxclmsqe4yv2ry885pw", "split": 1, "payout_threshold_msat": "500000"},{"label" : "Dave", "destination": "02ffefcc4240dd5f339e6e451f0eceadd7e1f2d3c3b74ae256f53b6ae8f575d91a", "split": 1, "payout_threshold_msat": "500000"},{"label" : "Erin", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq2a9lj8dwfgefqvnl7yc8jyhtcxxhzdzq5memcz7769ja3c0jzvys", "split": 1, "payout_threshold_msat": "500000"}]'
+[{"description" : "Guitarist", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy", "split": 0.333333, "payout_threshold_msat": "5000000", "fees_incurred_by": "local"},{"description" : "Drums", "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c", "split": 0.333333, "payout_threshold_msat": "10000000", "fees_incurred_by": "remote"},{"description" : "Tuba", "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6", "split": 0.333333, "payout_threshold_msat": "5000000", "fees_incurred_by": "local"}]
 ```
 
 ```bash
-lightning-cli prism-create -k members="$MEMBERS_JSON"
+lightning-cli prism-create -k description="Band Prism" members="$MEMBERS_JSON" outlay_factor="0.8"
 ```
 
 ```json
 {
-   "prism_id": "prism1",
-   "timestamp": 1715877268,
+   "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+   "description": "Band Prism",
+   "timestamp": 1718764199,
    "outlay_factor": 0.8,
    "prism_members": [
       {
-         "member_id": "1c00f7de-fd5e-4b21-a869-2a79226e8275",
-         "label": "Carol",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqvqmtjepktzl0sqz6fhadxphh7mmnrjxc6sjlf0schhjmm86yd57x",
-         "split": 1,
-         "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+         "description": "Guitarist",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy",
+         "split": 0.333333,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 5000000
       },
       {
-         "member_id": "841f869b-1a8b-4153-9a44-1fd50ce53989",
-         "label": "Dave",
-         "destination": "023fe8d7f9fddf9568cc31c1b0cf339d965a522166f9d1e3185186023d311922cf",
-         "split": 1,
+         "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
+         "description": "Drums",
+         "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c",
+         "split": 0.333333,
          "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "payout_threshold_msat": 10000000
       },
       {
-         "member_id": "28c5107d-e18b-4b99-8706-dac6ad8017cb",
-         "label": "Erin",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0nqkyg3z3hh6mhse7naf8njpdyzuw0067zj35vcelp6u8r3zkc3j",
-         "split": 1,
-         "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+         "description": "Tuba",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6",
+         "split": 0.333333,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 5000000
       }
    ]
 }
 ```
 
-Setting the `outlay_factor` to `0.8` means that total outlays will be only 80% of the incoming amount. This is an implicit "pay-to-self". This feature allows a Prism member to host a prism.
+Setting the `outlay_factor` to `0.8` means that total outlays will be only 80% of the incoming amount. This is an implicit "pay-to-self" of 20%. This feature allows a Prism member to host the prism. Note that if `destination` is a pubkey, then [keysend](https://docs.corelightning.org/reference/lightning-keysend) is used for payouts.
 
 ### Delete a prism
 
@@ -107,79 +103,82 @@ Run the following command to view a prism policy. (Note that you can add a `pris
 
 ```json
 {
-   "prisms": {
-      "prism_id": "prism1",
-      "timestamp": 1715879764,
-      "outlay_factor": 0.8,
-      "prism_members": [
-         {
-            "member_id": "088db12c-5bbc-4ecd-bd9f-66553f6dc277",
-            "label": "Carol",
-            "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtrvcsycd8dqycyzsqp3nf8kjtjw448ad2sxclmsqe4yv2ry885pw",
-            "split": 1,
-            "fees_incurred_by": "remote",
-            "payout_threshold_msat": "500000"
-         },
-         {
-            "member_id": "1cfa8bf2-f251-4891-ae08-b812d214fa07",
-            "label": "Dave",
-            "destination": "02ffefcc4240dd5f339e6e451f0eceadd7e1f2d3c3b74ae256f53b6ae8f575d91a",
-            "split": 1,
-            "fees_incurred_by": "remote",
-            "payout_threshold_msat": "500000"
-         },
-         {
-            "member_id": "fb639dd9-8d07-4ca9-9fbc-5ae08505627a",
-            "label": "Erin",
-            "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq2a9lj8dwfgefqvnl7yc8jyhtcxxhzdzq5memcz7769ja3c0jzvys",
-            "split": 1,
-            "fees_incurred_by": "remote",
-            "payout_threshold_msat": "500000"
-         }
-      ]
-   }
+   "prisms": [
+      {
+         "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+         "description": "prism1",
+         "timestamp": 1718722200,
+         "outlay_factor": 0.8,
+         "prism_members": [
+            {
+               "member_id": "b2dd7d8a70567a0e23308a6a77b38d603eaf2baca5da320082184a9951063a95",
+               "description": "Carol",
+               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0d9gxlr2q2c9rp0lkqjyztvwcl8g7gzjgu2trnwll8lraquy35vq",
+               "split": 1.0,
+               "fees_incurred_by": "local",
+               "payout_threshold_msat": 5000000
+            },
+            {
+               "member_id": "809a721743350c0c49a7b444ad3aeaf1341fdd48d1bf510e08b008edab72dc70",
+               "description": "Dave",
+               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwv5lnjcufs7jmsh2r7wmj45mp35z822tz69n2j07gy64qn475j2c",
+               "split": 1.0,
+               "fees_incurred_by": "remote",
+               "payout_threshold_msat": 10000000
+            },
+            {
+               "member_id": "849dc45741d52a071b0ed4ca14b7a182e82fcad6a60cf9b0025c903411263085",
+               "description": "Erin",
+               "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqwfg6tm3xapdfr0q0lqr3q5sujzznv3f9ff6wfvhl36m6scf3wzpy",
+               "split": 1.0,
+               "fees_incurred_by": "local",
+               "payout_threshold_msat": 5000000
+            }
+         ]
+      }
+   ]
 }
 ```
 
 ## Prism-Pay - Executes a Payout
 
-`lighting-cli prism-pay -k prism_id=prism1 amount_msat=1000000`
+`lightning-cli prism-pay -k prism_id=f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d amount_msat=10000000`
 
-When run, this RPC command will execute (i.e., pay-out) a prism. This is useful if you need to interactively execute a prism payout [another CLN plugin](https://github.com/farscapian/lnplay/tree/tabconf/lnplay/clightning/cln-plugins/lnplaylive). You can specify the optional `label` paramemter to associate this payout to some external `id`.
+When run, this RPC command will execute (i.e., pay-out) a prism. 
 
-> Note, Prism payouts via `prism-pay` DO NOT respect the payment_threshold. Your node will pay for all member payout fees when using `prism-pay`. Consider adding a binding so that fees can be tracked by maintaing a member outlay.
+> WARNING! prism-pay DOES NOT have an associated income event to account for payouts! Consider adding a binding so that fees can be tracked by maintaing a member outlay. Also, Prism payouts via `prism-pay` DO NOT respect the `payment_threshold` since this is only relevant to bindings. 
 
 ```json
 {
    "prism_member_payouts": {
-      "088db12c-5bbc-4ecd-bd9f-66553f6dc277": {
-         "destination": "02c6cc409869da026082800319a4f692e4ead4fd6aa06c7f70066a46286439e817",
-         "payment_hash": "abb1fcaaaacd541969d1edaebd5f9f01c6da75f333daaab124a813c0c3be55fc",
-         "created_at": 1715879764.8129447,
+      "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279": {
+         "destination": "02ed12cb4a37b65032c9c8551deb3ccae9532481a1a04267dfeb02f96f887e8462",
+         "payment_hash": "556de902e890674edc26af197e95f5e7b9281f8d104381d7c03cacf8cbcca5ea",
+         "created_at": 1718764199.7347724,
          "parts": 1,
-         "amount_msat": 3333333,
-         "amount_sent_msat": 3333333,
-         "payment_preimage": "b4abf87c99cf6861161083fc35e7483b7d88a685394d8f70fb92324a4afc5fd7",
+         "amount_msat": 2666666,
+         "amount_sent_msat": 2666666,
+         "payment_preimage": "70253f59527db2191d45d95be86ca47e593684f7e426710f24529612216b1172",
          "status": "complete"
       },
-      "1cfa8bf2-f251-4891-ae08-b812d214fa07": {
-         "destination": "02ffefcc4240dd5f339e6e451f0eceadd7e1f2d3c3b74ae256f53b6ae8f575d91a",
-         "payment_hash": "ef6c217ce60c2ef048bc308060eb76a39d91c36f4ce36cf579669a056270fe33",
-         "created_at": 1715879765.7926252,
+      "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d": {
+         "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c",
+         "payment_hash": "61c58e680b30751b8b5435280d435639ae6feef67d3b7c38aa2d0ebc6ab359a2",
+         "created_at": 1718764200.7018805,
          "parts": 1,
-         "amount_msat": 3333333,
-         "amount_sent_msat": 3333333,
-         "payment_preimage": "0f95f40f4ff52ab9b4a22f75f8769e750ac231e142bf1597c449c635f3738610",
+         "amount_msat": 2666666,
+         "amount_sent_msat": 2666666,
+         "payment_preimage": "3ac15217d8f62c4c5d301b0f3a22794f9bfcaad496a20488fbc64318da893091",
          "status": "complete"
       },
-      "fb639dd9-8d07-4ca9-9fbc-5ae08505627a": {
-         "destination": "02ba5fc8ed7251948193ff8983c8975e0c6b89a205379de05ef68b2ec70f909848",
-         "payment_hash": "12f4cf34789dfb73d3162b3f204c97d7a28ee6d8c7ff5689db994ed67da4b207",
-         "created_at": 1715879766.762006,
+      "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b": {
+         "destination": "03e0a35646d33d25b85ca89314c6705be228bb137365dd8fdbfd8fd32fcfbb2cdd",
+         "payment_hash": "97f31109bc0fcb07491a4b73b6d63d0a5d8ccdc3234123d70dd2cfd651825168",
+         "created_at": 1718764201.6202407,
          "parts": 1,
-         "amount_msat": 3333333,
-         "amount_sent_msat": 3333333,
-         "payment_preimage": "9e82e3ff68a84d8937923028a76052898ec9366d9f08ae7ce0b5a26ac4d6a77f",
+         "amount_msat": 2666666,
+         "amount_sent_msat": 2666666,
+         "payment_preimage": "11ccae76acd177b40ebc324de0a1fb29c79b97e0d6ad3adc61883d8a4c6ee5bb",
          "status": "complete"
       }
    }
@@ -194,47 +193,47 @@ Often you will want your prisms to be paid out whenever you have an incoming pay
 
 ### Create a binding
 
-`lightning-cli -k prism-bindingadd -k offer_id=458f1a21f5d24158dd756c44735f11fe688d4d5d0d97fd8b33235b634a2ca52f prism_id=prism1`
+`lightning-cli prism-bindingadd -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d prism_id=f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d`
 
-Binds a prism to either a bolt12 offer such that the prism will be executed upon incoming payment.
+The above command binds a prism (`prism_id`) to a bolt12 offer with the specified `offer_id`.
 
 ```json
 {
    "status": "must-create",
-   "timestamp": 1715879765,
-   "offer_id": "2a5afc3132b75e6c30a3ad932507f83c27c57fa96e56a6ff856b67db9e12d9a9",
-   "prism_id": "prism3",
+   "timestamp": 1718764200,
+   "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
+   "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
    "prism_binding_key": [
       "prism",
       "v2",
       "bind",
       "bolt12",
-      "2a5afc3132b75e6c30a3ad932507f83c27c57fa96e56a6ff856b67db9e12d9a9"
+      "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d"
    ],
    "prism_members": [
       {
-         "member_id": "064e2765-6773-4177-8c83-218e48fce2e4",
-         "label": "Carol",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtrvcsycd8dqycyzsqp3nf8kjtjw448ad2sxclmsqe4yv2ry885pw",
-         "split": 1,
-         "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+         "description": "Guitarist",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pqtk39j62x7m9qvkfep23m6euet54xfyp5xsyye7lavp0jmug06zxy",
+         "split": 0.333333,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 5000000
       },
       {
-         "member_id": "180e2490-c389-4926-8325-819d00d497de",
-         "label": "Dave",
-         "destination": "02ffefcc4240dd5f339e6e451f0eceadd7e1f2d3c3b74ae256f53b6ae8f575d91a",
-         "split": 1,
+         "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
+         "description": "Drums",
+         "destination": "02e4cc35ff6e7d43edc71db8146ae558f5b00a6d1e783e9ab10ad63bd82975502c",
+         "split": 0.333333,
          "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "payout_threshold_msat": 10000000
       },
       {
-         "member_id": "ae1aecc2-ff10-487e-9221-271050ce4949",
-         "label": "Erin",
-         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq2a9lj8dwfgefqvnl7yc8jyhtcxxhzdzq5memcz7769ja3c0jzvys",
-         "split": 1,
-         "fees_incurred_by": "remote",
-         "payout_threshold_msat": "500000"
+         "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+         "description": "Tuba",
+         "destination": "lno1qgsqvgnwgcg35z6ee2h3yczraddm72xrfua9uve2rlrm9deu7xyfzrc2qajx2enpw4k8g93pq0s2x4jx6v7jtwzu4zf3f3nst03z3wcnwdjamr7mlk8axt70hvkd6",
+         "split": 0.333333,
+         "fees_incurred_by": "local",
+         "payout_threshold_msat": 5000000
       }
    ]
 }
@@ -244,43 +243,69 @@ Binds a prism to either a bolt12 offer such that the prism will be executed upon
 
 Want to see your bindings? Run `prism-bindinglist`. Add an `offer_id` to view a specific binding.
 
-`lightning-cli -k prism-bindinglist 2a5afc3132b75e6c30a3ad932507f83c27c57fa96e56a6ff856b67db9e12d9a9`
+`lightning-cli -k prism-bindinglist -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d`
 
 ```json
 {
-   "bolt12_prism_bindings": {
-      "offer_id": "2a5afc3132b75e6c30a3ad932507f83c27c57fa96e56a6ff856b67db9e12d9a9",
-      "prism_id": "prism3",
-      "timestamp": 1715879765,
-      "member_outlays": [
-         {
-            "member_id": "064e2765-6773-4177-8c83-218e48fce2e4",
-            "outlay_msat": "0"
-         },
-         {
-            "member_id": "180e2490-c389-4926-8325-819d00d497de",
-            "outlay_msat": "0"
-         },
-         {
-            "member_id": "ae1aecc2-ff10-487e-9221-271050ce4949",
-            "outlay_msat": "0"
-         }
-      ]
-   }
+   "bolt12_prism_bindings": [
+      {
+         "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
+         "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+         "timestamp": 1718764200,
+         "member_outlays": [
+            {
+               "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+               "outlay_msat": 0
+            },
+            {
+               "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
+               "outlay_msat": 5333330
+            },
+            {
+               "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+               "outlay_msat": -1866669
+            }
+         ]
+      }
+   ]
 }
 ```
 
-Notice that outlay property? That's how the prism plugin deals with failed payments AND Lightning Network fees. When a prism binding has an incoming payment, prism member outlays in the binding are increased according the prism policy and incoming amount.
+The `outlay_msat` property is how the prism plugin deals with failed payments and to account for payout fees. When a prism binding has an incoming payment, prism member outlays in the binding are increased according the prism policy and incoming amount. When `fees_incurred_by=remote` and a payment to a prism member succeeds, the outlay is decremented by the total amount of the payment including fees paid. When `fees_incurred_by=local`, fees are paid by the node operator hosting the prism.
 
-When `fees_incurred_by=remote` and a payment to a prism member succeeds, the outlay is decremented by the total amount of the payment including fees paid. When `fees_incurred_by=local`, fees are paid by the node operator hosting the prism. Prism member payouts occur when outlays exceed the `payout_threshold_msat` in the respective prism policy. Until then, outlays accumulate and eventually get paid-out. 
+Prism member payouts occur when outlays exceed the `payout_threshold_msat` in the respective prism policy. Until then, outlays accumulate and eventually get paid-out.
 
-If a payment to a prism member fails for whatever reason, the outlay remains unchanged.
+If a payment to a prism member fails for whatever reason, the outlay remains unchanged and payout is deferred.
 
 ### Set a Binding Member Outlay
 
 Say you have outstanding outlays that aren't clearing for whatever reason (e.g., unreachable node in offer). If you know the individual, you can always remit the sats with another wallet. In those cases, you will want to first zeroize the outlays for that member in the binding:
 
-`lightning-cli prism-bindingmemberoutlayreset -k offer_id=404b719986d3f1f86cb25248e98ae2e5657bf17fe50c90afbbafcb29223c6464 member_id=81be6243-cb59-4567-b61b-c234cef23edf new_outlay_msat=0`
+`lightning-cli prism-bindingmemberoutlayreset -k offer_id=c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d member_id=3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b new_outlay_msat="-2500000"`
+
+```json
+{
+   "bolt12_prism_bindings": {
+      "offer_id": "c618514017a44b7bcce8edd842ad057bfde4fe0fdef0b00cec840c7264c8e08d",
+      "prism_id": "f0ab738d7a7dd92004e8c0f2bd9426d33b22288f2964c5634e019000cfd8353d",
+      "timestamp": 1718764200,
+      "member_outlays": [
+         {
+            "member_id": "c0772494d0d83318cf47ea1dbabcf3e37df2218090f9f20585867f135c241279",
+            "outlay_msat": 1066666
+         },
+         {
+            "member_id": "d624d9b334b06d84560f1095d153001cb8ae829a8270d6fe29fa6d715efd538d",
+            "outlay_msat": 6399996
+         },
+         {
+            "member_id": "3f921a0dc8b927d8389aed3536e2b4596c4bcfac752bc674ac1025523c25e42b",
+            "outlay_msat": -2500000
+         }
+      ]
+   }
+}
+```
 
 Note that since we're tracking outlays, if they actually owe us money, we can set the outlay value to a negative number. As income events flow in, the outlay will eventually turn positive again, accounting for what they owe us.
 
@@ -290,4 +315,4 @@ You can remove a binding by running `prism-bindingremove offer_id`.
 
 ## How to contribute
 
-There is a copy of the [startup_regtest](https://github.com/ElementsProject/lightning/blob/master/contrib/startup_regtest.sh) script from the c-lightning repo [contrib dir](./contrib/) for local development. Consider joining our Telegram group at [roygbiv.guide/contact](roygbiv.guide/contact).
+There is a copy of the [startup_regtest](https://github.com/ElementsProject/lightning/blob/master/contrib/startup_regtest.sh) script from the c-lightning repo [contrib dir](./contrib/) for local development. Consider joining our Telegram group at [roygbiv.guide/contact](https://www.roygbiv.guide/contact).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A CLN plugin for creating and interacting with prisms based on [BOLT12](https://
 
 > _BOLT12 is currently experimental and you will need to add the **--experimental-offers** flag when starting lightningd_
 
+## WARNING
+
+> This software should be considered for Testing and Evaluation purposes only!
+
 ## Background
 
 This started as the winning hackathon project at [bitcoin++](https://btcpp.dev/) 2023 in Austin, Tx.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ When `fees_incurred_by=remote` and a payment to a prism member succeeds, the out
 
 If a payment to a prism member fails for whatever reason, the outlay remains unchanged.
 
+### Set a Binding Member Outlay
+
+Say you have outstanding outlays that aren't clearing for whatever reason (e.g., unreachable node in offer). If you know the individual, you can always remit the sats with another wallet. In those cases, you will want to first zeroize the outlays for that member in the binding:
+
+`lightning-cli prism-bindingmemberoutlayreset -k offer_id=404b719986d3f1f86cb25248e98ae2e5657bf17fe50c90afbbafcb29223c6464 member_id=81be6243-cb59-4567-b61b-c234cef23edf new_outlay_msat=0`
+
+Note that since we're tracking outlays, if they actually owe us money, we can set the outlay value to a negative number. As income events flow in, the outlay will eventually turn positive again, accounting for what they owe us.
+
 ### Remove a binding
 
 You can remove a binding by running `prism-bindingremove offer_id`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ lightning-cli prism-create -k description="Band Prism" members="$MEMBERS_JSON" o
 }
 ```
 
-Setting the `outlay_factor` to `0.8` means that total outlays will be only 80% of the incoming amount. This is an implicit "pay-to-self" of 20%. This feature allows a Prism member to host the prism. Note that if `destination` is a pubkey, then [keysend](https://docs.corelightning.org/reference/lightning-keysend) is used for payouts.
+Setting the `outlay_factor` to `0.75` means that total outlays will be only 75% of the incoming amount. This is an implicit "pay-to-self" of 25%. This feature allows a Prism member to host the prism.
+
+> An `outlay_factor` of `1.1` means total outlays will be 110% of incoming events. This can be used for things like "employer matching" or similar schemes.
+
+Split percentages are normalized over all members of the prism. So, in the case above, each prism member will receive an equal split (i.e., 33.33%) of the total outlays.
+
+> Note that if `destination` is a node pubkey, [keysend](https://docs.corelightning.org/reference/lightning-keysend) is used for payouts instead of BOLT12.
 
 ### Delete a prism
 

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -34,15 +34,21 @@ def init(options, configuration, plugin, **kwargs):
 
 
 @plugin.method("prism-create")
-def createprism(plugin, members, prism_id="", outlay_factor: float = 1.0, pay_to_self_enabled: bool = False):
+def createprism(plugin, members, description: str = "", outlay_factor: float = 1.0, pay_to_self_enabled: bool = False):
     '''Create a prism.'''
 
-    plugin.log(f"prism-create invoked having an outlay_factor of {outlay_factor}", "info")
+    if description == "":
+        raise Exception("ERROR: you need to set a description.")
+
+    plugin.log(f"prism-create invoked having an outlay_factor of {outlay_factor} and a description='{description}'", "info")
 
     prism_members = [Member(plugin=plugin, member_dict=m) for m in members]
 
+    if description == "":
+        raise Exception("You must provide a unique destription!")
+
     # create a new prism object (this is used for our return object only)
-    prism = Prism.create(plugin=plugin, prism_id=prism_id, members=prism_members, outlay_factor=outlay_factor)
+    prism = Prism.create(plugin=plugin, description=description, members=prism_members, outlay_factor=outlay_factor)
 
     # now we want to create a unique offer that is associated with this prism
     # this offer facilitates pay-to-self-destination use case.

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -292,8 +292,10 @@ def prism_execute(plugin, prism_id, amount_msat=0, label=""):
 
     if prism is None:
         raise Exception("ERROR: could not find prism.")
-
-    pay_results = prism.pay(amount_msat=amount_msat)
+    
+    total_outlays = amount_msat * prism.outlay_factor
+    plugin.log(f"Total outlays will be {total_outlays} after applying an outlay factor of {prism.outlay_factor} to the income amount {amount_msat}.")
+    pay_results = prism.pay(amount_msat=total_outlays)
 
     return {
             "prism_member_payouts": pay_results

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -205,8 +205,8 @@ def bindprism(plugin: Plugin, prism_id, offer_id=None, invoice_label=""):
 
 
 
-# adds a binding to the database.
-@plugin.method("prism-bindingmemberoutlayreset")
+# set the outlay for a binding-member.
+@plugin.method("prism-setoutlay")
 def set_binding_member_outlay(plugin: Plugin, offer_id=None, member_id=None, new_outlay_msat=0):
     '''Change the member outlay value for a specific prism-binding-member.'''
 

--- a/bolt12-prism.py
+++ b/bolt12-prism.py
@@ -197,6 +197,35 @@ def bindprism(plugin: Plugin, prism_id, offer_id=None, invoice_label=""):
 
     return add_binding_result
 
+
+
+# adds a binding to the database.
+@plugin.method("prism-bindingmemberoutlayreset")
+def set_binding_member_outlay(plugin: Plugin, offer_id=None, member_id=None, new_outlay_msat=0):
+    '''Change the member outlay value for a specific prism-binding-member.'''
+
+    # Ensure new_outlay_msat is converted to an integer
+    try:
+        new_outlay_msat = int(new_outlay_msat)
+    except ValueError:
+        raise ValueError("new_outlay_msat must be convertible to an integer")
+
+    # then we're going to return a single binding.
+    binding = PrismBinding.get(plugin, offer_id)
+
+    if not binding:
+        raise Exception("ERROR: could not find a binding for this offer.")
+
+    plugin.log(f"Updating outlay for Prism Binding offer_id={offer_id}, member_id={member_id}, new outlay: '{new_outlay_msat}msat'", "info")
+
+    PrismBinding.set_member_outlay(binding, member_id, new_outlay_msat)
+
+    prism_response = {
+        f"bolt12_prism_bindings": binding.to_dict()
+    }
+
+    return prism_response
+
 @plugin.method("prism-bindingremove")
 def remove_prism_binding(plugin, offer_id=None, invoice_label=""):
     '''Removes a prism binding.'''

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-python3 -m pytest .

--- a/lib.py
+++ b/lib.py
@@ -18,8 +18,7 @@ except ModuleNotFoundError as err:
                       'result': {'disable': str(err)}}))
     sys.exit(1)
 
-# TODO: find a way to define this dynamically or decide that doesn't make sense to do
-prism_db_version = "v2"
+prism_db_version = "v2.1"
 
 pubkeyRegex = re.compile(r'^0[2-3][0-9a-fA-F]{64}$')
 bolt12Regex = re.compile(

--- a/lib.py
+++ b/lib.py
@@ -1,6 +1,6 @@
 try:
     from typing import List
-    from pyln.client import Plugin, RpcError
+    from pyln.client import Plugin, RpcError, Millisatoshi
     import re
     import os
     import uuid
@@ -346,22 +346,22 @@ class Prism:
 
                     status = payment["status"]
                     if status != "complete":
-                        self._plugin.log(f"Failed to pay member {member_id}")
+                        self._plugin.log(f"Failed to pay member {m.id}")
                         continue
 
                     # update the member outlay with the payment amount (respecting fee accounting)
-                    total_amount_sent = payment["amount_sent_msat"]
-                    total_amount_sent_minus_fees = payment["amount_msat"]
+                    total_amount_sent: Millisatoshi = payment["amount_sent_msat"]
+                    total_amount_sent_minus_fees: Millisatoshi = payment["amount_msat"]
 
                     self._plugin.log(f"total_amount_sent: {total_amount_sent}", 'debug')
                     self._plugin.log(f"total_amount_sent_minus_fees: {total_amount_sent_minus_fees}", 'debug')
 
                     new_outlay = None
                     if m.fees_incurred_by == "remote":
-                        new_outlay = member_msat - total_amount_sent
+                        new_outlay = member_msat - int(total_amount_sent)
                         self._plugin.log(f"fees_incurred_by is set to remote. New outlay: {member_msat}-{total_amount_sent}={new_outlay}")
                     elif m.fees_incurred_by == "local":
-                        new_outlay = member_msat - total_amount_sent_minus_fees
+                        new_outlay = member_msat - int(total_amount_sent_minus_fees)
                         self._plugin.log(f"fees_incurred_by is set to local. New outlay is {member_msat}-{total_amount_sent_minus_fees}={new_outlay}")
                     else:
                         raise Exception("If this happens then we have some input validation issues.")

--- a/lib.py
+++ b/lib.py
@@ -312,17 +312,28 @@ class Prism:
                         self._plugin.log(f"bolt12_payment:  {payment}")
                     else:
                         self._plugin.log(f"Could not fetch an invoice from the remote peer.", "warn")
-
                 except RpcError as e:
                     self._plugin.log(f"Prism member bolt12 payment did not complete.:  {e}", 'warn')
+                    continue
+                except Exception as e:
+                    self._plugin.log(f"Prism member bolt12 payment did not complete.:  {e}", 'warn')
+                    continue
+
             elif pubkeyRegex.match(m.destination):
                 try:
                     self._plugin.log(f"Attempting keysend payment for {member_msat}msats to node with pubkey {m.destination}", 'debug')
                     payment = self._plugin.rpc.keysend(destination=m.destination, amount_msat=member_msat)
                     self._plugin.log(f"keysend_payment:  {payment}")
                 except RpcError as e:
+                    self._plugin.log(f"Prism member bolt12 payment did not complete.:  {e}", 'warn')
+                    continue
+                except Exception as e:
                     self._plugin.log(f"Prism member keysend payment did not complete:  {e}", 'warn')
+                    continue
+            else:
+                raise Exception("ERROR: The destination was an invalid format. This should never happen!")
 
+            results[m.id] = None
             if payment is not None:
                 results[m.id] = payment
 

--- a/lib.py
+++ b/lib.py
@@ -397,6 +397,15 @@ class PrismBinding:
 
         return PrismBinding.from_db_string(plugin, string=binding_records[0].get('string'), bind_to=bind_to, bolt_version=bolt_version)
 
+    @staticmethod
+    def set_member_outlay(binding: None, member_id: str, new_outlay_value=0):
+
+        binding.outlays[member_id] = int(new_outlay_value)
+
+        # TODO this saves the entire prism bindings; we probably need something more
+        # precise that saves only the binding-member. But this works for now
+        binding.save()
+
     # is is the revers of the method above. It return all prism-bindings,
     # but keyed on offer_id, as stored in the database.
 
@@ -433,7 +442,7 @@ class PrismBinding:
         binding_value = {
             "prism_id": prism_id,
             "timestamp": timestamp,
-            "member_outlays": {member.id: "0msat" for member in members}
+            "member_outlays": {member.id: 0 for member in members}
         }
 
         # save the record

--- a/lib.py
+++ b/lib.py
@@ -36,8 +36,8 @@ class Member:
         if not isinstance(member, dict):
             raise ValueError("Each member in the list must be a dictionary.")
 
-        if not isinstance(member["label"], str):
-            raise ValueError("Member 'label' must be a string.")
+        if not isinstance(member["description"], str):
+            raise ValueError("Member 'description' must be a string.")
 
         if not isinstance(member["destination"], str):
             raise ValueError("Member 'destination' must be a string")
@@ -89,10 +89,7 @@ class Member:
 
     def __init__(self, plugin: Plugin, member_dict=None):
         self.validate(member_dict)
-
-        self.id = member_dict.get("member_id") if member_dict.get(
-            "member_id") else str(uuid.uuid4())
-        self.label: str = member_dict.get("label")
+        self.description: str = member_dict.get("description")
         self.destination: str = member_dict.get("destination")
         self.split: str = member_dict.get("split")
         self.fees_incurred_by: str = member_dict.get(
@@ -116,7 +113,7 @@ class Member:
     def to_json(self):
         return json.dumps({
             "member_id": self.id,
-            "label": self.label,
+            "description": self.description,
             "destination": self.destination,
             "split": self.split,
             # TODO: shold this be at the prism level instead?
@@ -127,7 +124,7 @@ class Member:
     def to_dict(self):
         return {
             "member_id": self.id,
-            "label": self.label,
+            "description": self.description,
             "destination": self.destination,
             "split": self.split,
             "fees_incurred_by": self.fees_incurred_by,
@@ -145,13 +142,15 @@ class Prism:
 
         prism_id = prism_dict.get("prism_id")
 
+        description = prism_dict.get("description")
+
         members = Member.find_many(plugin, prism_dict.get("prism_members"))
 
         timestamp = prism_dict.get("timestamp")
 
         outlay_factor = prism_dict.get("outlay_factor")
 
-        return Prism(plugin, outlay_factor=outlay_factor, timestamp=timestamp, prism_id=prism_id, members=members)
+        return Prism(plugin, outlay_factor=outlay_factor, description=description, timestamp=timestamp, members=members)
     
     @staticmethod
     def get(plugin: Plugin, prism_id: str):
@@ -176,9 +175,9 @@ class Prism:
         return prism_ids
     
     @staticmethod
-    def create(plugin: Plugin, outlay_factor, prism_id: str = None, members: List[Member] = None):
+    def create(plugin: Plugin, outlay_factor, description: str = None, members: List[Member] = None):
         timestamp = round(time.time())
-        prism = Prism(plugin, timestamp=timestamp, prism_id=prism_id, members=members, outlay_factor=outlay_factor)
+        prism = Prism(plugin, timestamp=timestamp, description=description, members=members, outlay_factor=outlay_factor)
         prism.save()
         return prism
 
@@ -206,10 +205,11 @@ class Prism:
 
         return our_bindings
 
-    def __init__(self, plugin: Plugin, outlay_factor: float, timestamp: str, prism_id: str = None, members: List[Member] = None):
+    def __init__(self, plugin: Plugin, outlay_factor: float, timestamp: str, description: str = "", members: List[Member] = None):
+
         self.validate(members)
         self.members = members
-        self.id = prism_id if prism_id else str(uuid.uuid4())
+        self.description = description
         self.timestamp = timestamp
         self.outlay_factor = outlay_factor
         self._plugin = plugin
@@ -222,6 +222,7 @@ class Prism:
             members = [member.to_dict() for member in self.members]
         return json.dumps({
             "prism_id": self.id,
+            "description": self.description,
             "timestamp": self.timestamp,
             "outlay_factor": self.outlay_factor,
             "prism_members": members
@@ -230,6 +231,7 @@ class Prism:
     def to_dict(self):
         return {
             "prism_id": self.id,
+            "description": self.description,
             "timestamp": self.timestamp,
             "outlay_factor": self.outlay_factor,
             "prism_members": [member.to_dict() for member in self.members]

--- a/lib.py
+++ b/lib.py
@@ -84,6 +84,7 @@ class Member:
 
     def __init__(self, plugin: Plugin, member_dict=None):
         self.validate(member_dict)
+        self.id: str = member_dict.get("member_id") if member_dict.get("member_id") else hashlib.sha256(str(uuid.uuid4()).encode('utf-8')).hexdigest()
         self.description: str = member_dict.get("description")
         self.destination: str = member_dict.get("destination")
         self.split: float = member_dict.get("split")
@@ -147,7 +148,7 @@ class Prism:
 
         outlay_factor = prism_dict.get("outlay_factor")
 
-        return Prism(plugin, outlay_factor=outlay_factor, description=description, timestamp=timestamp, members=members)
+        return Prism(plugin, outlay_factor=outlay_factor, description=description, timestamp=timestamp, members=members, prism_id=prism_id)
     
     @staticmethod
     def get(plugin: Plugin, prism_id: str):
@@ -202,7 +203,7 @@ class Prism:
 
         return our_bindings
 
-    def __init__(self, plugin: Plugin, outlay_factor: float, timestamp: str, description: str = "", members: List[Member] = None):
+    def __init__(self, plugin: Plugin, outlay_factor: float, timestamp: str, description: str = "", members: List[Member] = None, prism_id: str = ""):
 
         self.validate(members)
         self.members = members
@@ -210,6 +211,7 @@ class Prism:
         self.timestamp = timestamp
         self.outlay_factor = outlay_factor
         self._plugin = plugin
+        self.id: str = prism_id if prism_id != "" else hashlib.sha256(str(uuid.uuid4()).encode('utf-8')).hexdigest()
 
     def to_json(self, member_ids_only=False):
         members = []

--- a/lib.py
+++ b/lib.py
@@ -49,13 +49,17 @@ class Member:
         if not isinstance(member["split"], float):
             raise ValueError("Member 'split' must be an float (e.g., 2.0)")
 
-        member['fees_incurred_by'] = member.get('fees_incurred_by', "remote")
+        fees_incurred_by = member.get('fees_incurred_by', "remote")
+        allowed_values_icb = ["local", "remote"]
+        if fees_incurred_by not in allowed_values_icb:
+            raise Exception("'fees_incurred_by' can only be 'local' or 'remote'.")
 
-        # TODO
-        member['payout_threshold_msat'] = member.get('payout_threshold_msat', 0)
+        member_payout = int(member.get('payout_threshold_msat', 0))
+        if member_payout < 0:
+            raise Exception("'payout_threshold_msat' must be greater than or equal to 0.")
 
-        # TODO also check to see if the user provided MORE fields than is allowed.
-
+        member['payout_threshold_msat'] = member_payout
+        
     @staticmethod
     def get(plugin: Plugin, member_id: str):
         member_record = plugin.rpc.listdatastore(

--- a/lib.py
+++ b/lib.py
@@ -46,14 +46,9 @@ class Member:
             raise Exception(
                 "Destination must be a valid lightning node pubkey or bolt12 offer.")
 
-        if not isinstance(member["split"], int):
-            raise ValueError("Member 'split' must be an integer")
+        if not isinstance(member["split"], float):
+            raise ValueError("Member 'split' must be an float (e.g., 2.0)")
 
-        if member["split"] < 1 or member["split"] > 1000:
-            raise ValueError(
-                "Member 'split' must be an integer between 1 and 1000")
-
-        # TODO fees_incurred_by should be used in outlay calculations; valid are local/remote
         member['fees_incurred_by'] = member.get('fees_incurred_by', "remote")
 
         # TODO
@@ -91,7 +86,9 @@ class Member:
         self.validate(member_dict)
         self.description: str = member_dict.get("description")
         self.destination: str = member_dict.get("destination")
-        self.split: str = member_dict.get("split")
+        self.split: float = member_dict.get("split")
+        if self.split <= 0:
+            raise Exception("The split MUST be a positive number (e.g., 2.0)")
         self.fees_incurred_by: str = member_dict.get(
             "fees_incurred_by") if member_dict.get("fees_incurred_by") else "remote"
         self.payout_threshold_msat: int = int(member_dict.get(

--- a/lib.py
+++ b/lib.py
@@ -118,7 +118,6 @@ class Member:
             "description": self.description,
             "destination": self.destination,
             "split": self.split,
-            # TODO: shold this be at the prism level instead?
             "fees_incurred_by": self.fees_incurred_by,
             "payout_threshold_msat": self.payout_threshold_msat
         })
@@ -363,7 +362,7 @@ class Prism:
                         self._plugin.log(f"fees_incurred_by is set to remote. New outlay: {member_msat}-{total_amount_sent}={new_outlay}")
                     elif m.fees_incurred_by == "local":
                         new_outlay = member_msat - total_amount_sent_minus_fees
-                        self._plugin.log(f"fees_incurred_by is set to local. New outlay is {new_outlay}")
+                        self._plugin.log(f"fees_incurred_by is set to local. New outlay is {member_msat}-{total_amount_sent_minus_fees}={new_outlay}")
                     else:
                         raise Exception("If this happens then we have some input validation issues.")
 
@@ -477,8 +476,6 @@ class PrismBinding:
 
         prism = Prism.get(plugin=plugin, prism_id=prism_id)
 
-        plugin.log(f"prism: {prism}")
-
         if not prism:
             raise Exception(f"Could not find prism: {prism_id}")
         members = prism.members
@@ -555,8 +552,6 @@ class PrismBinding:
                                "bind", bolt_version, offer_id]
 
     def to_dict(self):
-        sha256 = hashlib.sha256()
-        sha256.update(self.offer_id.encode('utf-8'))
 
         return {
             "offer_id": self.offer_id,

--- a/lib.py
+++ b/lib.py
@@ -446,7 +446,10 @@ class PrismBinding:
     @staticmethod
     def set_member_outlay(binding: None, member_id: str, new_outlay_value=0):
 
-        binding.outlays[member_id] = int(new_outlay_value)
+        if member_id in binding.outlays:
+            binding.outlays[member_id] = int(new_outlay_value)
+        else:            
+            raise Exception(f"ERROR: Could not find a member with a member_id of {member_id}")
 
         # TODO this saves the entire prism bindings; we probably need something more
         # precise that saves only the binding-member. But this works for now

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+docker system prune -f
+
 # first build the image if it doesn't exit.
 BOLT12_PRISM_IMAGE_NAME="bolt12-prism-pyln-testing:v24.02.2"
 docker buildx build . -t "$BOLT12_PRISM_IMAGE_NAME" --load

--- a/test_bolt12_prism.py
+++ b/test_bolt12_prism.py
@@ -363,7 +363,7 @@ def test_update_outlay(node_factory, bitcoind):
     new_outlay_msat = 1000000
 
     # just updates a single member's outlay
-    updated_binding = l2.rpc.call("prism-bindingmemberoutlayreset", {"offer_id": l2_offer["offer_id"], "member_id": lead_singer_id, "new_outlay_msat": new_outlay_msat})["bolt12_prism_bindings"]
+    updated_binding = l2.rpc.call("prism-setoutlay", {"offer_id": l2_offer["offer_id"], "member_id": lead_singer_id, "new_outlay_msat": new_outlay_msat})["bolt12_prism_bindings"]
 
     print(f"updated_binding: {updated_binding}")
 

--- a/test_bolt12_prism.py
+++ b/test_bolt12_prism.py
@@ -77,26 +77,28 @@ def test_general_prism(node_factory, bitcoind):
 
     members_json = [
         {
-            "label": "Lead-Singer",
+            "description": "Lead-Singer",
             "destination": l3_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
         {
-            "label": "Drummer",
+            "description": "Drummer",
             "destination": l4_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
         {
-            "label": "Guitarist",
+            "description": "Guitarist",
             "destination": l5_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
     ]
-    prism1_id = "prism1"
+    description = "prism1"
 
-    l2.rpc.call(
-        "prism-create", {"members": members_json, "prism_id": prism1_id}
+    prism = l2.rpc.call(
+        "prism-create", {"members": members_json, "description": description}
     )
+
+    prism1_id = prism["prism_id"]
 
     prism_ids = [prism["prism_id"] for prism in l2.rpc.call("prism-list")["prisms"]]
     assert prism1_id in prism_ids
@@ -169,47 +171,31 @@ def test_splits(node_factory, bitcoind):
     l3_offer = l3.rpc.offer("any", "CTO")
     l4_offer = l4.rpc.offer("any", "Janitor")
 
-    prism1_id = "prism1"
-
-    members_json_float = [
-        {
-            "label": "CEO",
-            "destination": l2_offer["bolt12"],
-            "split": 0.7,
-        },
-        {
-            "label": "CTO",
-            "destination": l3_offer["bolt12"],
-            "split": 0.3,
-        },
-    ]
-    with pytest.raises(RpcError, match="must be an integer"):
-        l1.rpc.call(
-            "prism-create",
-            {"members": members_json_float, "prism_id": prism1_id},
-        )
+    prism1_description = "prism1"
 
     members_json = [
         {
-            "label": "CEO",
+            "description": "CEO",
             "destination": l2_offer["bolt12"],
-            "split": 5,
+            "split": 5.0,
         },
         {
-            "label": "CTO",
+            "description": "CTO",
             "destination": l3_offer["bolt12"],
-            "split": 3,
+            "split": 3.0,
         },
         {
-            "label": "Janitor",
+            "description": "Janitor",
             "destination": l4_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
     ]
 
-    l1.rpc.call(
-        "prism-create", {"members": members_json, "prism_id": prism1_id}
+    prism = l1.rpc.call(
+        "prism-create", {"members": members_json, "description": prism1_description}
     )
+    prism1_id = prism["prism_id"]
+
     l1.rpc.call("prism-pay", {"prism_id": prism1_id, "amount_msat": 1_000_000})
     wait_for(
         lambda: l2.rpc.listpeerchannels()["channels"][0]["to_us_msat"] > 555_000
@@ -255,27 +241,28 @@ def test_payment_threshold(node_factory, bitcoind):
 
     members_json = [
         {
-            "label": "Lead-Singer",
+            "description": "Lead-Singer",
             "destination": l3_offer["bolt12"],
-            "split": 1,
-            "payout_threshold_msat": "500000",
+            "split": 1.0,
+            "payout_threshold_msat": 500000,
         },
         {
-            "label": "Drummer",
+            "description": "Drummer",
             "destination": l4_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
         {
-            "label": "Guitarist",
+            "description": "Guitarist",
             "destination": l5_offer["bolt12"],
-            "split": 1,
+            "split": 1.0,
         },
     ]
-    prism1_id = "prism1"
+    prism1_description = "prism1"
 
-    l2.rpc.call(
-        "prism-create", {"members": members_json, "prism_id": prism1_id}
+    prism = l2.rpc.call(
+        "prism-create", {"members": members_json, "description": prism1_description}
     )
+    prism1_id = prism["prism_id"]
 
     l2_offer = l2.rpc.offer("any", "Prism")
     l2.rpc.call(

--- a/test_bolt12_prism.py
+++ b/test_bolt12_prism.py
@@ -293,3 +293,82 @@ def test_payment_threshold(node_factory, bitcoind):
     wait_for(
         lambda: l5.rpc.listpeerchannels()["channels"][0]["to_us_msat"] > 600_000
     )
+
+def test_update_outlay(node_factory, bitcoind):
+    l1, l2, l3, l4, l5 = node_factory.get_nodes(
+        5, opts={"experimental-offers": None}
+    )
+    nodes = [l1, l2, l3, l4, l5]
+
+    # fund nodes, create channels, l2 is the prism
+    #
+    #          -> l3
+    # l1 -> l2 -> l4
+    #          -> l5
+    #
+    l1.fundwallet(10_000_000)
+    l2.fundwallet(10_000_000)
+    l1.rpc.fundchannel(l2.info["id"] + "@localhost:" + str(l2.port), 1_000_000)
+    l2.rpc.fundchannel(l3.info["id"] + "@localhost:" + str(l3.port), 1_000_000)
+    bitcoind.generate_block(1)
+    sync_blockheight(bitcoind, nodes)
+    l2.rpc.fundchannel(l4.info["id"] + "@localhost:" + str(l4.port), 1_000_000)
+    bitcoind.generate_block(1)
+    sync_blockheight(bitcoind, nodes)
+    l2.rpc.fundchannel(l5.info["id"] + "@localhost:" + str(l5.port), 1_000_000)
+    bitcoind.generate_block(6)
+    sync_blockheight(bitcoind, nodes)
+
+    l2.rpc.plugin_start(plugin_path)
+
+    l3_offer = l3.rpc.offer("any", "Lead-Singer")
+    l4_offer = l4.rpc.offer("any", "Drummer")
+    l5_offer = l5.rpc.offer("any", "Guitarist")
+
+    members_json = [
+        {
+            "description": "Lead-Singer",
+            "destination": l3_offer["bolt12"],
+            "split": 1.0,
+            "payout_threshold_msat": 500000,
+        },
+        {
+            "description": "Drummer",
+            "destination": l4_offer["bolt12"],
+            "split": 1.0,
+        },
+        {
+            "description": "Guitarist",
+            "destination": l5_offer["bolt12"],
+            "split": 1.0,
+        },
+    ]
+    prism1_description = "prism1"
+
+    prism = l2.rpc.call(
+        "prism-create", {"members": members_json, "description": prism1_description}
+    )
+    prism1_id = prism["prism_id"]
+
+    # generate offer and bind to it
+    l2_offer = l2.rpc.offer("any", "Prism")
+    binding = l2.rpc.call(
+        "prism-bindingadd",
+        {"offer_id": l2_offer["offer_id"], "prism_id": prism1_id},
+    )
+
+    lead_singer_id = [member["member_id"] for member in binding["prism_members"] if member["description"] == "Lead-Singer"][0]
+    assert lead_singer_id is not None, "Lead-Singer not found in prism"
+
+    new_outlay_msat = 1000000
+
+    # just updates a single member's outlay
+    updated_binding = l2.rpc.call("prism-bindingmemberoutlayreset", {"offer_id": l2_offer["offer_id"], "member_id": lead_singer_id, "new_outlay_msat": new_outlay_msat})["bolt12_prism_bindings"]
+
+    print(f"updated_binding: {updated_binding}")
+
+    assert updated_binding["member_outlays"][0]["outlay_msat"] == new_outlay_msat, "Outlay not updated correctly"
+
+    sanity_check = l2.rpc.call("prism-bindinglist", {"offer_id": l2_offer["offer_id"]})["bolt12_prism_bindings"]
+
+    assert sanity_check["member_outlays"][0]["outlay_msat"] == new_outlay_msat, "Outlay not updated in DB correctly"


### PR DESCRIPTION
On the production ROYGBIV prism instance, I was having some issues with the plugin not fully completing when an incoming payment was received. The plugin was making payments on mainnet and attempting to update the outlay to a negative number (mainnet is the only place we've tested where fees are non-zero). Negative numbers for outlay should be possible. The issue is, we originally defined the outlay to be a Millisatoshi type, which apparently doesn't support negative numbers.  So the first part of this PR includes fixing that issue. I completely remove Millisatoshi from the picture and rely on python's built-in `int` type for tracking the outlays. This has the correct behavior with negative numbers. I also added RPC method for setting the outlay value (closing #95 and #50 ).  I should also mention that I REMOVED the update_outlays function and moved that logic Prism.pay. This allows us to update outlays after each payment attempt rather than waiting to update outlays until all payments have completed (assuming they complete!). 

Unfortunately, this change impacts the API. Since this is a necessary fix, I decided to go ahead and implement other Issues which also affect the API. Per the advice from some CLN folks, I updated the `prism_id` and `member_id` mechanism (#88 #87 #86 ). Now prisms and members each get a unique ID at creation time and in format similar to offer_ids. In addition, I changed "label" values to "description". I also changed the "split" parameter to type float. This allows users to be more expressive in terms of how they provide the split. I also made `payment_threshold_msat` a positive int.

There's also a bug fix: #96 and documentation updates. I updated the example to a Band Prism so we can hopefully demonstrate relatable prism infrastructure to people.