### PR TITLE
Remove BOLT11 Receiving Support; Remove Python 3.8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             bitcoind-version: ["26.1"]
             experimental: [1]
             deprecated: [0]
-            python-version: ["3.8", "3.12"]
+            python-version: ["3.12"]
             os: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR resolves the issue described here: https://github.com/gudnuf/bolt12-prism/issues/101 Basically it makes no sense to track outlays for BOLT11 since they are independent from each other!

This commit also includes fix for the CI issue. I just removed the 3.8 python from the testing. Maybe we can add it back later after the issue is resolved upstream? 